### PR TITLE
Add TreeSitter node path functionality to Neovim utils

### DIFF
--- a/nvim/lua/utils.lua
+++ b/nvim/lua/utils.lua
@@ -40,4 +40,51 @@ function M.find_aider_terminal()
   return nil
 end
 
+local function get_node_at_cursor()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local row, col = cursor[1] - 1, cursor[2]
+
+  local parser = vim.treesitter.get_parser(bufnr)
+  local tree = parser:parse()[1]
+  local root = tree:root()
+
+  return root:named_descendant_for_range(row, col, row, col)
+end
+
+local function get_node_path(node)
+  local path = {}
+  local current = node
+
+  while current do
+    table.insert(path, 1, {
+      type = current:type(),
+      text = vim.treesitter.get_node_text(current, 0)
+    })
+    current = current:parent()
+  end
+
+  return path
+end
+
+local function format_node_path(node_path)
+  local parts = {}
+  for _, node_info in ipairs(node_path) do
+    vim.print(node_info)
+    -- Extract identifier name from node text
+    local name = node_info.text:match("^%s*(%w+)")
+    if name then
+      table.insert(parts, name)
+    end
+  end
+
+  return table.concat(parts, " > ")
+end
+
+function M.get_node_path_at_cursor()
+  local node = get_node_at_cursor()
+  if not node then return nil end
+  return format_node_path(get_node_path(get_node_at_cursor()))
+end
+
 return M


### PR DESCRIPTION
## Summary
- Add TreeSitter integration to track cursor position within code structure
- Implement hierarchical node path from cursor to root for better code navigation context

## Test plan
- [ ] Test get_node_path_at_cursor() function in various file types
- [ ] Verify node path formatting displays meaningful structure
- [ ] Test with different cursor positions in nested code blocks

🤖 Generated with [Claude Code](https://claude.ai/code)